### PR TITLE
Add permissions and JWT authentication to Books API

### DIFF
--- a/books/permissions.py
+++ b/books/permissions.py
@@ -1,0 +1,8 @@
+from rest_framework.permissions import SAFE_METHODS, BasePermission
+
+
+class IsAdminOrReadOnly(BasePermission):
+    def has_permission(self, request, view):
+        if request.method in SAFE_METHODS:
+            return True
+        return request.user and request.user.is_staff

--- a/books/views.py
+++ b/books/views.py
@@ -1,9 +1,11 @@
 from rest_framework.viewsets import ModelViewSet
 
 from books.models import Book
+from books.permissions import IsAdminOrReadOnly
 from books.serializers import BookSerializer
 
 
 class BookViewSet(ModelViewSet):
     queryset = Book.objects.all()
     serializer_class = BookSerializer
+    permission_classes = (IsAdminOrReadOnly,)

--- a/library/settings.py
+++ b/library/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.1/ref/settings/
 """
 import os
+from datetime import timedelta
 
 from dotenv import load_dotenv
 from pathlib import Path
@@ -135,3 +136,15 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    )
+}
+
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=100),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=7),
+    "ROTATE_REFRESH_TOKENS": True
+}

--- a/library/urls.py
+++ b/library/urls.py
@@ -18,8 +18,23 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from debug_toolbar.toolbar import debug_toolbar_urls
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+)
+
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/v1/", include("books.urls"), name="books"),
+    path(
+        "api/v1/token/",
+        TokenObtainPairView.as_view(),
+        name="token_obtain_pair"
+    ),
+    path(
+        "api/v1/token/refresh/",
+        TokenRefreshView.as_view(),
+        name="token_refresh"
+    ),
 ] + debug_toolbar_urls()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,12 @@ asgiref==3.8.1
 Django==5.1.6
 django-debug-toolbar==5.0.1
 djangorestframework==3.15.2
+djangorestframework_simplejwt==5.5.0
 flake8==7.1.2
 mccabe==0.7.0
 pycodestyle==2.12.1
 pyflakes==3.2.0
+PyJWT==2.9.0
 python-dotenv==1.0.1
 sqlparse==0.5.3
 tzdata==2025.1


### PR DESCRIPTION
- Added IsAdminOrReadOnly permission for Books API
- Restricted create/update/delete actions to admin users
- Allowed all users (even unauthenticated) to list books
- Configured JWT authentication and token endpoints