### PR TITLE
Implement Borrowing Create endpoint

### DIFF
--- a/borrowings/serializers.py
+++ b/borrowings/serializers.py
@@ -21,15 +21,5 @@ class BorrowingListSerializer(serializers.ModelSerializer):
         )
 
 
-class BorrowingRetrieveSerializer(serializers.ModelSerializer):
+class BorrowingRetrieveSerializer(BorrowingListSerializer):
     book = BookSerializer(read_only=True)
-
-    class Meta:
-        model = Borrowing
-        fields = (
-            "id",
-            "book",
-            "borrow_date",
-            "expected_return_date",
-            "actual_return_date"
-        )

--- a/borrowings/serializers.py
+++ b/borrowings/serializers.py
@@ -23,3 +23,26 @@ class BorrowingListSerializer(serializers.ModelSerializer):
 
 class BorrowingRetrieveSerializer(BorrowingListSerializer):
     book = BookSerializer(read_only=True)
+
+
+class BorrowingCreateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Borrowing
+        fields = ("book", "borrow_date", "expected_return_date")
+
+    def validate(self, data):
+        book = data.get("book")
+        borrow_date = data.get("borrow_date")
+        expected_return_date = data.get("expected_return_date")
+
+        if book.inventory <= 0:
+            raise serializers.ValidationError(
+                {"book": "This book is not available for borrowing."}
+            )
+
+        Borrowing.validate_borrowing(
+            borrow_date=borrow_date,
+            expected_return_date=expected_return_date,
+        )
+
+        return data

--- a/borrowings/views.py
+++ b/borrowings/views.py
@@ -1,11 +1,15 @@
-from rest_framework import mixins
+from django.db import transaction
+from rest_framework import mixins, status
+from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from borrowings.models import Borrowing
 from borrowings.serializers import (
     BorrowingListSerializer,
-    BorrowingRetrieveSerializer
+    BorrowingRetrieveSerializer,
+    BorrowingCreateSerializer
 )
 
 
@@ -27,5 +31,26 @@ class BorrowingsViewSet(
     def get_serializer_class(self):
         if self.action == "retrieve":
             return BorrowingRetrieveSerializer
+        if self.action == "borrow_book":
+            return BorrowingCreateSerializer
 
         return BorrowingListSerializer
+
+    @action(detail=False, methods=["POST"], url_path="borrow")
+    def borrow_book(self, request):
+        serializer = self.get_serializer(
+            data=request.data,
+            context={"request": request}
+        )
+
+        if serializer.is_valid():
+            with transaction.atomic():
+                book = serializer.validated_data["book"]
+                book.inventory -= 1
+                book.save(update_fields=["inventory"])
+
+                serializer.save(user=request.user)
+
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
- Added `BorrowingCreateSerializer` with validation to ensure:
  - A book cannot be borrowed if `inventory = 0`.
  - The borrowing dates are logically correct using `validate_borrowing()`.
- Implemented `borrow_book()` action in `BorrowingsViewSet`:
  - Uses `POST /api/v1/borrowings/borrow/` to create a borrowing.
  - Automatically assigns `user` to the borrowing.
  - Ensures the `inventory` of the book is decreased only if borrowing is successfully created.
  - Wrapped the transaction in `with transaction.atomic()` to maintain data consistency.