### PR TITLE
Add filtering for Borrowings List endpoint

### DIFF
--- a/borrowings/serializers.py
+++ b/borrowings/serializers.py
@@ -6,8 +6,14 @@ from borrowings.models import Borrowing
 
 class BorrowingListSerializer(serializers.ModelSerializer):
     book = serializers.SlugRelatedField(
+        many=False,
         read_only=True,
         slug_field="title"
+    )
+    user = serializers.SlugRelatedField(
+        many=False,
+        read_only=True,
+        slug_field="email"
     )
 
     class Meta:
@@ -17,7 +23,8 @@ class BorrowingListSerializer(serializers.ModelSerializer):
             "book",
             "borrow_date",
             "expected_return_date",
-            "actual_return_date"
+            "actual_return_date",
+            "user"
         )
 
 


### PR DESCRIPTION
- Implemented filtering for borrowings list.
- Added `is_active=true/false` to filter active borrowings.
- Added `user_id` filter for admin users.
- Non-admin users can only see their own borrowings.
- Borrowings remain accessible only to authenticated users.
- **Added `user` field (email) to `BorrowingListSerializer` for better API response readability.**